### PR TITLE
Feature/language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## [0.21.0 (2022-12-28)](https://github.com/axe-api/axe-api/compare/0.21.0...0.20.4)
+
+### Features
+
+- Added `i18n` support. [#44](https://github.com/axe-api/axe-api/issues/44)
+
 ## [0.20.4 (2022-12-24)](https://github.com/axe-api/axe-api/compare/0.20.4...0.20.3)
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/express": "^4.17.15",
-        "accept-language-parser": "^1.5.0",
         "change-case": "^4.1.2",
         "dotenv": "^14.2.0",
         "express": "^4.18.2",
@@ -2954,11 +2953,6 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
-    },
-    "node_modules/accept-language-parser": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/accept-language-parser/-/accept-language-parser-1.5.0.tgz",
-      "integrity": "sha512-QhyTbMLYo0BBGg1aWbeMG4ekWtds/31BrEU+DONOg/7ax23vxpL03Pb7/zBmha2v7vdD3AyzZVWBVGEZxKOXWw=="
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -12099,11 +12093,6 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
-    },
-    "accept-language-parser": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/accept-language-parser/-/accept-language-parser-1.5.0.tgz",
-      "integrity": "sha512-QhyTbMLYo0BBGg1aWbeMG4ekWtds/31BrEU+DONOg/7ax23vxpL03Pb7/zBmha2v7vdD3AyzZVWBVGEZxKOXWw=="
     },
     "accepts": {
       "version": "1.3.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axe-api",
-  "version": "0.20.4",
+  "version": "0.21.0",
   "description": "AXE API is a simple tool which has been created based on Express and Knex.js to create Rest APIs quickly.",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -30,7 +30,6 @@
   },
   "dependencies": {
     "@types/express": "^4.17.15",
-    "accept-language-parser": "^1.5.0",
     "change-case": "^4.1.2",
     "dotenv": "^14.2.0",
     "express": "^4.18.2",

--- a/scripts/test-mysql57.sh
+++ b/scripts/test-mysql57.sh
@@ -10,7 +10,7 @@ echo "Waiting for 15 seconds"
 sleep 15
 
 echo "Starting the application and tests"
-cd ./tests/integrations && node index.js mysql57
+cd ./tests/integrations && npm run build && node index.js mysql57
 
 echo "Downing the database container"
 cd ../../

--- a/scripts/test-mysql8.sh
+++ b/scripts/test-mysql8.sh
@@ -10,7 +10,7 @@ echo "Waiting for 10 seconds"
 sleep 10
 
 echo "Starting the application and tests"
-cd ./tests/integrations && node index.js mysql8
+cd ./tests/integrations && npm run build && node index.js mysql8
 
 echo "Downing the database container"
 cd ../../

--- a/scripts/test-postgres.sh
+++ b/scripts/test-postgres.sh
@@ -10,7 +10,7 @@ echo "Waiting for 10 seconds"
 sleep 10
 
 echo "Starting the application and tests"
-cd ./tests/integrations && node index.js postgres
+cd ./tests/integrations && npm run build && node index.js postgres
 
 echo "Downing the database container"
 cd ../../

--- a/src/Handlers/PatchHandler.ts
+++ b/src/Handlers/PatchHandler.ts
@@ -53,7 +53,7 @@ export default async (pack: IRequestPack) => {
   const validationRules = model.instance.getValidationRules(requestMethod);
   if (validationRules) {
     // The validation language should be set
-    Validator.useLang(req.language);
+    Validator.useLang(req.currentLanguage.language);
 
     // Validate the data
     const validation = new Validator(formData, validationRules);

--- a/src/Handlers/StoreHandler.ts
+++ b/src/Handlers/StoreHandler.ts
@@ -25,7 +25,7 @@ export default async (pack: IRequestPack) => {
 
   if (validationRules) {
     // The validation language should be set
-    Validator.useLang(req.language);
+    Validator.useLang(req.currentLanguage.language);
 
     // Validate the data
     const validation = new Validator(formData, validationRules);

--- a/src/Handlers/UpdateHandler.ts
+++ b/src/Handlers/UpdateHandler.ts
@@ -50,7 +50,7 @@ export default async (pack: IRequestPack) => {
   const validationRules = model.instance.getValidationRules(requestMethod);
   if (validationRules) {
     // The validation language should be set
-    Validator.useLang(req.language);
+    Validator.useLang(req.currentLanguage.language);
 
     // Validate the data
     const validation = new Validator(formData, validationRules);

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -43,7 +43,19 @@ export interface IApplicationConfig extends IConfig {
   serializers:
     | ((data: any, request: Request) => void)[]
     | IHandlerBasedSerializer[];
+  supportedLanguages: string[];
   defaultLanguage: string;
+}
+
+export interface ILanguage {
+  title: string;
+  language: string;
+  region?: string | null;
+}
+
+export interface IAcceptedLanguage {
+  language: ILanguage;
+  quality: number;
 }
 
 export type IDatabaseConfig = Knex.Config;

--- a/src/Resolvers/AcceptLanguageResolver.ts
+++ b/src/Resolvers/AcceptLanguageResolver.ts
@@ -1,0 +1,92 @@
+import { IAcceptedLanguage, ILanguage } from "../Interfaces";
+
+class AcceptLanguageResolver {
+  static resolve(
+    value: string,
+    supportedLanguages: string[],
+    defaultLanguage: string
+  ): ILanguage {
+    value = value.trim();
+
+    if (value === "*") {
+      return this.toLanguageObject(defaultLanguage);
+    }
+
+    const languages = this.toSortedPreferences(value);
+
+    const perfectMatch = languages.find((item) =>
+      supportedLanguages.includes(item.language.title)
+    );
+
+    const anyMatch = languages.find((item) =>
+      supportedLanguages.includes(item.language.language)
+    );
+
+    if (perfectMatch && !anyMatch) {
+      return perfectMatch.language;
+    }
+
+    if (!perfectMatch && anyMatch) {
+      return anyMatch.language;
+    }
+
+    if (perfectMatch && anyMatch) {
+      if (perfectMatch.quality >= anyMatch.quality) {
+        return perfectMatch.language;
+      } else {
+        return this.toLanguageObject(anyMatch.language.language);
+      }
+    }
+
+    return this.toLanguageObject(defaultLanguage);
+  }
+
+  static toLanguageObject(key = ""): ILanguage {
+    const [language, region] = key.split("-");
+    return {
+      title: key,
+      language,
+      region: region || null,
+    };
+  }
+
+  private static toSortedPreferences(value: string): IAcceptedLanguage[] {
+    // Splitting by language definitons
+    const keys = value.split(",").map((key) => key.trim());
+    const languages: IAcceptedLanguage[] = [];
+
+    for (const key of keys) {
+      // Splitting by the quality values
+      const [code, quality] = key.split(";");
+
+      // Parsing the language code and the quality value
+      const item: IAcceptedLanguage = {
+        language: this.toLanguageObject(code),
+        quality: quality ? parseFloat(quality.replace("q=", "")) : 1,
+      };
+
+      languages.push(item);
+    }
+
+    // Sorting ASC
+    languages.sort((a, b) => {
+      if (a.quality === b.quality) {
+        return 0;
+      }
+
+      if (a.quality === null) {
+        return 1;
+      }
+
+      if (b.quality === null) {
+        return -1;
+      }
+
+      return a.quality < b.quality ? 1 : -1;
+    });
+
+    return languages;
+  }
+}
+
+export default AcceptLanguageResolver;

--- a/src/Resolvers/index.ts
+++ b/src/Resolvers/index.ts
@@ -1,3 +1,4 @@
+import AcceptLanguageResolver from "./AcceptLanguageResolver";
 import FileResolver from "./FileResolver";
 import FolderResolver from "./FolderResolver";
 import GeneralHookResolver from "./GeneralHookResolver";
@@ -6,6 +7,7 @@ import TransactionResolver from "./TransactionResolver";
 import WithQueryResolver from "./WithQueryResolver";
 
 export {
+  AcceptLanguageResolver,
   FileResolver,
   FolderResolver,
   GeneralHookResolver,

--- a/tests/integrations/scenarios/app/Config/Application.ts
+++ b/tests/integrations/scenarios/app/Config/Application.ts
@@ -7,6 +7,8 @@ const config: IApplicationConfig = {
   logLevel: LogLevels.INFO,
   transaction: [],
   serializers: [],
+  supportedLanguages: ["en", "de"],
+  defaultLanguage: "en",
 };
 
 export default config;

--- a/tests/integrations/scenarios/tests/01-user.spec.js
+++ b/tests/integrations/scenarios/tests/01-user.spec.js
@@ -111,4 +111,29 @@ describe("Axe API", () => {
     });
     expect(response.pagination.total).toBe(1);
   });
+
+  test("should be able to return form validation messages in German", async () => {
+    let validationError = false;
+    try {
+      await axios.post(
+        "/users",
+        {},
+        {
+          headers: {
+            "Accept-Language": "de;q=0.9, en;q=0.8",
+          },
+        }
+      );
+    } catch (error) {
+      validationError = true;
+      expect(error?.response?.data?.errors?.email).not.toBe(undefined);
+      expect(error.response.data.errors.email.length).toBe(1);
+      expect(error.response.data.errors.email[0]).toBe(
+        "Das email Feld muss ausgefüllt sein."
+      );
+      expect(error.response.headers["content-language"]).toBe("de");
+    }
+
+    expect(validationError).toBe(true);
+  });
 });

--- a/tests/unit/Resolvers/AcceptLanguageResolver.spec.ts
+++ b/tests/unit/Resolvers/AcceptLanguageResolver.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "@jest/globals";
+import { AcceptLanguageResolver } from "../../../src/Resolvers";
+
+describe("AcceptLanguageResolver", () => {
+  test(".toLanguageObject() should able to parse the language value correctly", async () => {
+    let result = AcceptLanguageResolver.toLanguageObject("en");
+    expect(result.title).toBe("en");
+    expect(result.language).toBe("en");
+    expect(result.region).toBe(null);
+
+    result = AcceptLanguageResolver.toLanguageObject("en-GB");
+    expect(result.title).toBe("en-GB");
+    expect(result.language).toBe("en");
+    expect(result.region).toBe("GB");
+  });
+
+  test(".resolve() should able to return the default language when the value is asterisk", async () => {
+    expect(AcceptLanguageResolver.resolve("*", ["en"], "en").title).toBe("en");
+    expect(AcceptLanguageResolver.resolve("*", ["en"], "en-GB").title).toBe(
+      "en-GB"
+    );
+  });
+
+  test(".resolve() should able to return the matched language", async () => {
+    let result = AcceptLanguageResolver.resolve(
+      "fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5",
+      ["en"],
+      "en"
+    );
+    expect(result.title).toBe("en");
+
+    result = AcceptLanguageResolver.resolve(
+      "fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5",
+      ["fr", "en"],
+      "en"
+    );
+    expect(result.title).toBe("fr");
+
+    result = AcceptLanguageResolver.resolve(
+      "fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5",
+      ["fr", "fr-CH", "en"],
+      "en"
+    );
+    expect(result.title).toBe("fr-CH");
+
+    result = AcceptLanguageResolver.resolve(
+      "fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5, fr-CH",
+      ["fr", "fr-CH", "en"],
+      "en"
+    );
+    expect(result.title).toBe("fr-CH");
+
+    result = AcceptLanguageResolver.resolve(
+      "fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5, fr-CH",
+      ["tr"],
+      "en"
+    );
+    expect(result.title).toBe("en");
+
+    result = AcceptLanguageResolver.resolve("en-GB;q=0.9", ["en"], "tr");
+    expect(result.title).toBe("en-GB");
+
+    result = AcceptLanguageResolver.resolve(
+      "tr-TR,en;q=0.8",
+      ["en", "tr"],
+      "en-GB"
+    );
+    expect(result.title).toBe("tr");
+  });
+});

--- a/types/express/index.d.ts
+++ b/types/express/index.d.ts
@@ -1,12 +1,11 @@
-import { Language } from "accept-language-parser";
+import { ILanguage } from "../Interfaces";
 
 export {};
 
 declare global {
   namespace Express {
     export interface Request {
-      language: string;
-      acceptedLanguages: Language[];
+      currentLanguage: ILanguage;
     }
   }
 }


### PR DESCRIPTION
## Description

https://github.com/axe-api/axe-api/issues/44

## Motivation and Context

Developers should be able to decide;
- which languages should be supported
- what is the default language

Also, `validatorjs` package should be able to return validation errors in different languages.

## How has this been tested?

- Added unit tests to the `Accept-Language` parser.

## Types of changes

- [ ] ~Bug fix~
- [x] New feature
- [ ] ~Breaking change~

## Checklist:

- [x] My changes require documentation change.
- [x] The changes have been documented in the [axe-api/docs](https://github.com/axe-api/docs) repository. (https://github.com/axe-api/docs/pull/46)
- [x] I added integration tests properly.
- [x] The changes require [axe-api-template](https://github.com/axe-api/axe-api-template) changes. (https://github.com/axe-api/axe-api-template/pull/7)
- [x] The changes require [dev-kit](https://github.com/axe-api/dev-kit) changes. (https://github.com/axe-api/dev-kit/pull/10)
