### PR TITLE
Windows/Linux path diffirence fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## [0.30.1 (2023-04-05)](https://github.com/axe-api/axe-api/compare/0.30.1...0.30.0)
+## [0.30.1 (2023-04-15)](https://github.com/axe-api/axe-api/compare/0.30.1...0.30.0)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## [0.30.1 (2023-04-05)](https://github.com/axe-api/axe-api/compare/0.30.1...0.30.0)
+
+### Fixed
+
+- Fixed URL slash character difference between windows and *nix [#164](https://github.com/axe-api/axe-api/issues/164)
+
 ## [0.30.0 (2023-04-05)](https://github.com/axe-api/axe-api/compare/0.30.0...0.22.0)
 
 ### Breaking Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "axe-api",
-  "version": "0.30.0-rc12",
+  "version": "0.30.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "axe-api",
-      "version": "0.30.0-rc12",
+      "version": "0.30.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axe-api",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "description": "AXE API is a simple tool which has been created based on Express and Knex.js to create Rest APIs quickly.",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/Builders/RouterBuilder.ts
+++ b/src/Builders/RouterBuilder.ts
@@ -82,7 +82,7 @@ class RouterBuilder {
 
       const urlCreator = API_ROUTE_TEMPLATES[handlerType];
       const url = urlCreator(
-        path.join(await this.getRootPrefix(), this.version.name),
+        `${await this.getRootPrefix()}/${this.version.name}`,
         urlPrefix,
         resource,
         model.instance.primaryKey

--- a/src/Builders/RouterBuilder.ts
+++ b/src/Builders/RouterBuilder.ts
@@ -1,5 +1,4 @@
 import pluralize from "pluralize";
-import path from "path";
 import { Knex } from "knex";
 import { Express, Request, Response, NextFunction } from "express";
 import { paramCase, camelCase } from "change-case";


### PR DESCRIPTION
## Description
We can use the `/` character in the URL,  `Path.join` function is join word with `/` on *nix but on Windows, it uses `\` character for os behavior.

Close #164
## Motivation and Context
  I hard-coded it.

## How has this been tested?
Tested on Windows 11 and Linux5 manually.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
