### PR TITLE
Default error handler behaivour changed

### DIFF
--- a/src/Builders/RouterBuilder.ts
+++ b/src/Builders/RouterBuilder.ts
@@ -336,14 +336,11 @@ class RouterBuilder {
         break;
 
       default:
-        // We should not show the real errors on production
-        if (process.env.NODE_ENV === "production") {
-          res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-            error: "An error occurredxx.",
-          });
-        }
-
-        throw error;
+        // We should log error and send general error response
+        LogService.getInstance().error(`SERVER ERROR: ${JSON.stringify({...error, message: error.message}, null, '  ')}`);
+        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+          error: "An error occurredxx.",
+        });
     }
   }
 

--- a/src/Builders/RouterBuilder.ts
+++ b/src/Builders/RouterBuilder.ts
@@ -11,12 +11,7 @@ import {
   IVersion,
 } from "../Interfaces";
 import { API_ROUTE_TEMPLATES } from "../constants";
-import {
-  HandlerTypes,
-  Relationships,
-  HttpMethods,
-  StatusCodes,
-} from "../Enums";
+import { HandlerTypes, Relationships, HttpMethods } from "../Enums";
 import HandlerFactory from "../Handlers/HandlerFactory";
 import ApiError from "../Exceptions/ApiError";
 import {
@@ -187,17 +182,21 @@ class RouterBuilder {
   ) {
     const docs = DocumentationService.getInstance();
     const app = await IoCService.useByType<Express>("App");
-    const handler = (req: Request, res: Response) => {
-      this.requestHandler(
-        handlerType,
-        req,
-        res,
-        model,
-        parentModel,
-        relation
-      ).catch((error) => {
-        this.sendErrorAsResponse(res, error);
-      });
+
+    const handler = async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        await this.requestHandler(
+          handlerType,
+          req,
+          res,
+          model,
+          parentModel,
+          relation
+        );
+      } catch (error: any) {
+        // Catch error then pass it to the express error handler
+        next(error);
+      }
     };
 
     switch (handlerType) {
@@ -337,10 +336,14 @@ class RouterBuilder {
 
       default:
         // We should log error and send general error response
-        LogService.getInstance().error(`SERVER ERROR: ${JSON.stringify({...error, message: error.message}, null, '  ')}`);
-        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-          error: "An error occurredxx.",
-        });
+        LogService.getInstance().error(
+          `SERVER ERROR: ${JSON.stringify(
+            { ...error, message: error.message },
+            null,
+            "  "
+          )}`
+        );
+        throw error;
     }
   }
 


### PR DESCRIPTION
## Description
If an error other than `ApiError` occurs, it logs it and then passes it to the express's default error handler

Fixed #155 
**Console**: 
![Screenshot_20230419_193556](https://user-images.githubusercontent.com/56413673/233142196-a780a20c-eacb-42af-a792-2e7aa351ec23.png)


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)