### PR TITLE
added 'all' keyword to the 'RESERVED_KEYWORDS' in constants.ts

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,6 +28,7 @@ export const RESERVED_KEYWORDS: string[] = [
   "hooks",
   "event",
   "events",
+  "all",
 ];
 
 export const DEFAULT_HANDLERS: HandlerTypes[] = [


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Added 'all' keyword to the 'RESERVED_KEYWORDS' in constants.ts
## Motivation and Context
all keyword should be added to the reserved keys.
Closes #230 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My changes requires documentation change.
- [ ] The changes have been documented in the [axe-api/docs](https://github.com/axe-api/docs) repository. (<!--- Please insert the PR link -->)
- [ ] I added integration tests properly.
- [ ] The changes require [axe-api-template](https://github.com/axe-api/axe-api-template) changes. (<!--- Please insert the PR link -->)
