### PR TITLE
Feature #276

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@babel/core": "^7.22.11",
         "@babel/preset-env": "^7.22.14",
         "@babel/preset-typescript": "^7.22.11",
+        "@elastic/elasticsearch": "^8.10.0",
         "@types/accept-language-parser": "^1.5.3",
         "@types/aws-lambda": "^8.10.119",
         "@types/cors": "^2.8.13",
@@ -1988,6 +1989,42 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@elastic/elasticsearch": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-8.10.0.tgz",
+      "integrity": "sha512-RIEyqz0D18bz/dK+wJltaak+7wKaxDELxuiwOJhuMrvbrBsYDFnEoTdP/TZ0YszHBgnRPGqBDBgH/FHNgHObiQ==",
+      "dev": true,
+      "dependencies": {
+        "@elastic/transport": "^8.3.4",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@elastic/transport": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@elastic/transport/-/transport-8.3.4.tgz",
+      "integrity": "sha512-+0o8o74sbzu3BO7oOZiP9ycjzzdOt4QwmMEjFc1zfO7M0Fh7QX1xrpKqZbSd8vBwihXNlSq/EnMPfgD2uFEmFg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4",
+        "hpagent": "^1.0.0",
+        "ms": "^2.1.3",
+        "secure-json-parse": "^2.4.0",
+        "tslib": "^2.4.0",
+        "undici": "^5.22.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@elastic/transport/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -2087,6 +2124,15 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
+      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@gar/promisify": {
@@ -7403,6 +7449,15 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
+    },
+    "node_modules/hpagent": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -13570,6 +13625,18 @@
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true
+    },
+    "node_modules/undici": {
+      "version": "5.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.0.tgz",
+      "integrity": "sha512-gM12DkXhlAc5+/TPe60iy9P6ETgVfqTuRJ6aQ4w8RYu0MqKuXhaq3/b86GfzDQnNA3NUO6aUNdvevrKH59D0Nw==",
+      "dev": true,
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@babel/core": "^7.22.11",
     "@babel/preset-env": "^7.22.14",
     "@babel/preset-typescript": "^7.22.11",
+    "@elastic/elasticsearch": "^8.10.0",
     "@types/accept-language-parser": "^1.5.3",
     "@types/aws-lambda": "^8.10.119",
     "@types/cors": "^2.8.13",

--- a/src/Builders/IndexBuilder.ts
+++ b/src/Builders/IndexBuilder.ts
@@ -1,0 +1,32 @@
+import { IoCService } from "../Services";
+import { IVersion } from "../Interfaces";
+import ElasticService from "../Services/ElasticService";
+
+class IndexBuilder {
+  private version: IVersion;
+
+  constructor(version: IVersion) {
+    this.version = version;
+  }
+
+  async build() {
+    // Filtering the models that need Elastic Search index
+    const models = this.version.modelList
+      .get()
+      .filter((model) => model.instance.search);
+
+    // No need to create any index
+    if (models.length === 0) {
+      return;
+    }
+
+    const elastic = await IoCService.use<ElasticService>("Elastic");
+
+    // Creating index for each model
+    for (const model of models) {
+      elastic.createIndex(model.name);
+    }
+  }
+}
+
+export default IndexBuilder;

--- a/src/Builders/SwaggerBuilder.ts
+++ b/src/Builders/SwaggerBuilder.ts
@@ -63,6 +63,7 @@ const SUMMARY_TEXTS: Record<string, string> = {
   [HandlerTypes.FORCE_DELETE]: "Force delete a {model}",
   [HandlerTypes.PATCH]: "Apply partial updates to a {model}",
   [HandlerTypes.ALL]: "Get all items on {model}",
+  [HandlerTypes.SEARCH]: "Full-text search on {model}",
 };
 
 const DESCRIPTION_TEXTS: Record<string, string> = {
@@ -74,6 +75,7 @@ const DESCRIPTION_TEXTS: Record<string, string> = {
   [HandlerTypes.FORCE_DELETE]: "Force delete a {model} by primary key",
   [HandlerTypes.PATCH]: "Apply partial updates to a {model} by primary key",
   [HandlerTypes.ALL]: "Get all items on {model}",
+  [HandlerTypes.SEARCH]: "Full-text search on {model} by using ElasticSearch",
 };
 
 const SINGLE_RETURN_ENDPOINTS: string[] = [
@@ -86,6 +88,7 @@ const SINGLE_RETURN_ENDPOINTS: string[] = [
 const ALLOWED_2XX_HANDLERS: string[] = [
   HandlerTypes.ALL,
   HandlerTypes.PAGINATE,
+  HandlerTypes.SEARCH,
   HandlerTypes.PATCH,
   HandlerTypes.SHOW,
   HandlerTypes.UPDATE,
@@ -380,6 +383,61 @@ const toRequestParameters = (endpoint: IRouteDocumentation) => {
           name: "sort",
           in: "query",
           description: "The field to sort the data (ASC: id, DESC: -id)",
+          required: false,
+          schema: {
+            type: "string",
+          },
+        },
+      ],
+    );
+  }
+
+  if (endpoint.handler === HandlerTypes.SEARCH) {
+    parameters.push(
+      ...[
+        {
+          name: "text",
+          in: "query",
+          description: "The search text",
+          required: true,
+          schema: {
+            type: "string",
+            default: "",
+          },
+        },
+        {
+          name: "page",
+          in: "query",
+          description: "The page number to list",
+          required: false,
+          schema: {
+            type: "integer",
+            default: 1,
+          },
+        },
+        {
+          name: "per_page",
+          in: "query",
+          description: "Number of records to list on a page",
+          required: false,
+          schema: {
+            type: "integer",
+            default: 10,
+          },
+        },
+        {
+          name: "fields",
+          in: "query",
+          description: "The model fields that can be fetched",
+          required: false,
+          schema: {
+            type: "string",
+          },
+        },
+        {
+          name: "with",
+          in: "query",
+          description: "Listable related models",
           required: false,
           schema: {
             type: "string",

--- a/src/Enums.ts
+++ b/src/Enums.ts
@@ -29,6 +29,7 @@ export enum HandlerTypes {
   FORCE_DELETE = "force_delete",
   PATCH = "patch",
   ALL = "all",
+  SEARCH = "search",
 }
 
 export enum HookFunctionTypes {

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -32,6 +32,7 @@ import { LoggerOptions } from "pino";
 import { IncomingMessage } from "http";
 import { ErrorHandleFunction } from "connect";
 import { RedisClientOptions } from "redis";
+import { ClientOptions } from "@elastic/elasticsearch";
 
 export interface IColumn extends Column {
   table_name: string;
@@ -111,6 +112,10 @@ export interface ICacheConfiguration {
   cacheKey?: (req: AxeRequest) => string;
 }
 
+export interface ISearchConfigutation {
+  indexPrefix: string;
+}
+
 export interface AxeConfig extends IConfig {
   env: string;
   port: number;
@@ -122,6 +127,8 @@ export interface AxeConfig extends IConfig {
   docs: boolean;
   redis: RedisClientOptions | undefined;
   cache: ICacheConfiguration;
+  elasticSearch: ClientOptions;
+  search: ISearchConfigutation;
 }
 
 export type IApplicationConfig = Partial<AxeConfig>;
@@ -288,6 +295,7 @@ export interface IQuery {
   fields: string[];
   with: IWith[];
   trashed: boolean;
+  text: string | null;
 }
 
 export interface IWhere {
@@ -368,4 +376,12 @@ export interface IForeignKeyTask {
 export interface IRouteParentPair {
   model: IModelService;
   paramName: string;
+}
+
+export interface IElasticSearchParameters {
+  req: AxeRequest;
+  model: IModelService;
+  relation: IRelation | null;
+  parentModel: IModelService | null;
+  text: string;
 }

--- a/src/Phases/Delete/ActionPhase.ts
+++ b/src/Phases/Delete/ActionPhase.ts
@@ -1,14 +1,45 @@
+import { IoCService } from "../../Services";
 import { IContext } from "../../Interfaces";
+import ElasticService from "../../Services/ElasticService";
+import { getSearchData } from "../../Handlers/Helpers";
 
 export default async (context: IContext) => {
+  const { model, req } = context;
+
   if (context.query) {
     // If there is a deletedAtColumn, it means that this table support soft-delete
-    if (context.model.instance.deletedAtColumn) {
+    if (model.instance.deletedAtColumn) {
       await context.query.update({
-        [context.model.instance.deletedAtColumn]: new Date(),
+        [model.instance.deletedAtColumn]: new Date(),
       });
+
+      // Fetching the latest version of the item
+      const item = await context
+        .database(model.instance.table)
+        .where(model.instance.primaryKey, req.params[model.instance.primaryKey])
+        .first();
+
+      // Updat the index values
+      if (model.instance.search) {
+        const elastic = await IoCService.use<ElasticService>("Elastic");
+        const body: any = getSearchData(model, item);
+        await elastic.update(
+          model.name,
+          context.item[model.instance.primaryKey],
+          body,
+        );
+      }
     } else {
       await context.query.delete();
+
+      // Updat the index values
+      if (model.instance.search) {
+        const elastic = await IoCService.use<ElasticService>("Elastic");
+        await elastic.delete(
+          model.name,
+          context.item[model.instance.primaryKey],
+        );
+      }
     }
   }
 };

--- a/src/Phases/ForceDelete/ActionPhase.ts
+++ b/src/Phases/ForceDelete/ActionPhase.ts
@@ -1,7 +1,17 @@
+import { IoCService } from "../../Services";
 import { IContext } from "../../Interfaces";
+import ElasticService from "../../Services/ElasticService";
 
 export default async (context: IContext) => {
+  const { model } = context;
+
   if (context.query) {
     await context.query.delete();
+
+    // Updat the index values
+    if (model.instance.search) {
+      const elastic = await IoCService.use<ElasticService>("Elastic");
+      await elastic.delete(model.name, context.item[model.instance.primaryKey]);
+    }
   }
 };

--- a/src/Phases/Search/FetchPhase.ts
+++ b/src/Phases/Search/FetchPhase.ts
@@ -1,0 +1,68 @@
+import { Knex } from "knex";
+import { IoCService } from "../../Services";
+import { IContext } from "../../Interfaces";
+import ElasticService from "../../Services/ElasticService";
+import { StatusCodes } from "../../Enums";
+
+export default async (context: IContext) => {
+  const { req, res, model, database, relation, parentModel } = context;
+  if (!context.query || !context.queryParser || !context.conditions) {
+    return res.status(500).json({ error: "Query is not parsed!" });
+  }
+
+  const { page, per_page, text } = context.conditions;
+
+  // The text parameter is required
+  if (!text || text.trim().length === 0) {
+    return res
+      .status(StatusCodes.BAD_REQUEST)
+      .json({ error: "`text` parameter is required" });
+  }
+
+  const elastic = await IoCService.use<ElasticService>("Elastic");
+
+  // We are using the default query prepare strategy. But developers are able to
+  // create their own custom logic if they want.
+  const esQuery = model.instance.getSearchQuery({
+    req,
+    model,
+    relation,
+    parentModel,
+    text: text || "",
+  });
+
+  // Getting the data from Elastic Search
+  const result = await elastic.search(model.name, page, per_page, esQuery);
+  const ids = result.hits.hits.map((item: any) => item._id);
+
+  // Preparing the query to fetch the items via database
+  context.query = (database as Knex)
+    .from(context.model.instance.table)
+    .whereIn(model.instance.primaryKey, ids);
+
+  // Users should be able to select some fields to show.
+  context.queryParser.applyFields(context.query, context.conditions.fields);
+
+  // Fetching the data
+  const data = await context.query;
+
+  // Calculating the pagination values
+  const from = (page - 1) * per_page;
+  const to = from + per_page;
+  const total: number = result.hits.total
+    ? (result.hits.total as any)?.value
+    : 1;
+
+  // Creates the reesponses
+  context.result = {
+    data,
+    pagination: {
+      total,
+      lastPage: Math.ceil(total / per_page),
+      per_page,
+      currentPage: page,
+      from,
+      to,
+    },
+  };
+};

--- a/src/Phases/Search/PreparePhase.ts
+++ b/src/Phases/Search/PreparePhase.ts
@@ -1,0 +1,17 @@
+import { QueryService } from "../../Services";
+import { IContext } from "../../Interfaces";
+import { Knex } from "knex";
+
+export default async (context: IContext) => {
+  context.queryParser = new QueryService(
+    context.model,
+    context.version.modelList.get(),
+    context.version.config,
+  );
+
+  // We should parse URL query string to use as condition in Lucid query
+  context.conditions = context.queryParser.get(context.req.query);
+
+  // Creating a new database query
+  context.query = (context.database as Knex).from(context.model.instance.table);
+};

--- a/src/Phases/Search/index.ts
+++ b/src/Phases/Search/index.ts
@@ -1,0 +1,7 @@
+import PreparePhase from "./PreparePhase";
+import FetchPhase from "./FetchPhase";
+
+export default {
+  PreparePhase,
+  FetchPhase,
+};

--- a/src/Phases/Update/ActionPhase.ts
+++ b/src/Phases/Update/ActionPhase.ts
@@ -1,20 +1,31 @@
+import { IoCService } from "../../Services";
 import { IContext } from "../../Interfaces";
+import ElasticService from "../../Services/ElasticService";
+import { getSearchData } from "../../Handlers/Helpers";
 
 export default async (context: IContext) => {
+  const { model } = context;
   if (context.query) {
+    // Updating the data
     await context.query
-      .where(
-        context.model.instance.primaryKey,
-        context.item[context.model.instance.primaryKey],
-      )
+      .where(model.instance.primaryKey, context.item[model.instance.primaryKey])
       .update(context.formData);
 
+    // Fetchinf the latest version of the item
     context.item = await context
-      .database(context.model.instance.table)
-      .where(
-        context.model.instance.primaryKey,
-        context.item[context.model.instance.primaryKey],
-      )
+      .database(model.instance.table)
+      .where(model.instance.primaryKey, context.item[model.instance.primaryKey])
       .first();
+
+    // Updat the index values
+    if (model.instance.search) {
+      const elastic = await IoCService.use<ElasticService>("Elastic");
+      const body: any = getSearchData(model, context.item);
+      await elastic.update(
+        model.name,
+        context.item[model.instance.primaryKey],
+        body,
+      );
+    }
   }
 };

--- a/src/Server.ts
+++ b/src/Server.ts
@@ -25,6 +25,8 @@ import App from "./Services/App";
 import { DEFAULT_APP_CONFIG } from "./constants";
 import RedisAdaptor from "./Middlewares/RateLimit/RedisAdaptor";
 import RateLimitMiddleware from "./Middlewares/RateLimit";
+import ElasticService from "./Services/ElasticService";
+import IndexBuilder from "./Builders/IndexBuilder";
 
 class Server {
   /**
@@ -68,6 +70,9 @@ class Server {
     IoCService.singleton("Redis", () => {
       return new RedisAdaptor(api.config.redis, "");
     });
+    IoCService.singleton("Elastic", () => {
+      return new ElasticService(api.config.search, api.config.elasticSearch);
+    });
   }
 
   private async analyzeVersions() {
@@ -79,6 +84,7 @@ class Server {
       await new ModelResolver(version).resolve();
       await new SchemaValidatorService(version).validate();
       await new ModelTreeBuilder(version).build();
+      await new IndexBuilder(version).build();
       await new RouterBuilder(version).build();
     }
   }

--- a/src/Services/ElasticService.ts
+++ b/src/Services/ElasticService.ts
@@ -1,0 +1,63 @@
+import { Client, ClientOptions } from "@elastic/elasticsearch";
+import LogService from "./LogService";
+import { ISearchConfigutation } from "src/Interfaces";
+
+class ElasticService {
+  private config: ISearchConfigutation;
+  private client: Client;
+
+  constructor(config: ISearchConfigutation, options: ClientOptions) {
+    this.config = config;
+    this.client = new Client(options);
+    LogService.debug("Elasticsearch connection has been completed.");
+  }
+
+  async createIndex(modelName: string) {
+    const index = this.toIndex(modelName);
+    const result = await this.client.indices.exists({ index });
+    if (result === false) {
+      await this.client.indices.create({ index });
+      LogService.debug(`ES.create({ index: ${index} })`);
+    }
+  }
+
+  async insert(modelName: string, id: string, body: any) {
+    const index = this.toIndex(modelName);
+    const result = await this.client.index({ index, id: id.toString(), body });
+    LogService.debug(`\t🔄 ES.insert(${index}) => ${id}`);
+    return result;
+  }
+
+  async update(modelName: string, id: string, doc: any) {
+    const index = this.toIndex(modelName);
+    const result = await this.client.update({ index, id: id.toString(), doc });
+    LogService.debug(`\t🔄 ES.update(${index}) => ${id}`);
+    return result;
+  }
+
+  async delete(modelName: string, id: string) {
+    const index = this.toIndex(modelName);
+    const result = await this.client.delete({ index, id: id.toString() });
+    LogService.debug(`\t🔄 ES.delete(${index}) => ${id}`);
+    return result;
+  }
+
+  async search(modelName: string, page: number, size: number, body: any) {
+    const index = this.toIndex(modelName);
+
+    LogService.debug(`\t🔄 ES.search(${index}) => ${JSON.stringify(body)}`);
+    return await this.client.search({
+      index,
+      body,
+      from: (page - 1) * size,
+      size,
+    });
+  }
+
+  private toIndex(modelName: string): string {
+    const prefix = this.config.indexPrefix ? `${this.config.indexPrefix}-` : "";
+    return `${prefix}${modelName.toLowerCase()}`.trim();
+  }
+}
+
+export default ElasticService;

--- a/src/Services/QueryService.ts
+++ b/src/Services/QueryService.ts
@@ -252,6 +252,7 @@ class QueryService {
       sort: this.parseSortingOptions(sections.get("sort")),
       q: this.parseCondition(q),
       with: withQueryResolver.resolve(sections.get("with") || ""),
+      text: sections.get("text") || null,
       trashed: sections.get("trashed")
         ? isBoolean(sections.get("trashed"))
         : false,
@@ -443,7 +444,7 @@ class QueryService {
       where.condition === ConditionTypes["NOT LIKE"]
     ) {
       const queryColumn = where.model.columns.find(
-        (column) => column.name === where.field
+        (column) => column.name === where.field,
       );
 
       if (
@@ -451,7 +452,7 @@ class QueryService {
         !STRING_COLUMN_TYPES.includes(queryColumn.data_type.toLowerCase())
       ) {
         throw new ApiError(
-          `Query field need to be string. Unacceptable query field: ${where.field}`
+          `Query field need to be string. Unacceptable query field: ${where.field}`,
         );
       }
 

--- a/src/Services/SchemaValidatorService.ts
+++ b/src/Services/SchemaValidatorService.ts
@@ -44,6 +44,7 @@ class SchemaValidatorService {
     this.version.modelList.get().forEach((model) => {
       this.checkModelReservedKeywordsOrFail(model);
       this.checkModelColumnsOrFail(model, this.getModelFillableColumns(model));
+      this.checkModelColumnsOrFail(model, this.getSearchColumns(model));
       this.checkModelColumnsOrFail(
         model,
         this.getModelFormValidationColumns(model),
@@ -163,6 +164,10 @@ class SchemaValidatorService {
       ...(config.PUT || []),
       ...(config.PATCH || []),
     ];
+  };
+
+  private getSearchColumns = (model: IModelService): string[] => {
+    return model.instance.search || [];
   };
 
   private getModelFormValidationColumns = (model: IModelService): string[] => {

--- a/tests/integrations/docker-compose.cockroach.yml
+++ b/tests/integrations/docker-compose.cockroach.yml
@@ -15,3 +15,15 @@ services:
     image: redis:latest
     ports:
       - "6380:6379"
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.1
+    container_name: elasticsearch
+    environment:
+      - discovery.type=single-node
+      - http.host=0.0.0.0
+      - transport.host=127.0.0.1
+      - xpack.security.enabled=false
+    ports:
+      - "9200:9200"
+      - "9300:9300"

--- a/tests/integrations/docker-compose.mariadb.yml
+++ b/tests/integrations/docker-compose.mariadb.yml
@@ -21,3 +21,15 @@ services:
     image: redis:latest
     ports:
       - "6380:6379"
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.1
+    container_name: elasticsearch
+    environment:
+      - discovery.type=single-node
+      - http.host=0.0.0.0
+      - transport.host=127.0.0.1
+      - xpack.security.enabled=false
+    ports:
+      - "9200:9200"
+      - "9300:9300"

--- a/tests/integrations/docker-compose.mysql57.yml
+++ b/tests/integrations/docker-compose.mysql57.yml
@@ -22,3 +22,15 @@ services:
     image: redis:latest
     ports:
       - "6380:6379"
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.1
+    container_name: elasticsearch
+    environment:
+      - discovery.type=single-node
+      - http.host=0.0.0.0
+      - transport.host=127.0.0.1
+      - xpack.security.enabled=false
+    ports:
+      - "9200:9200"
+      - "9300:9300"

--- a/tests/integrations/docker-compose.mysql8.yml
+++ b/tests/integrations/docker-compose.mysql8.yml
@@ -21,3 +21,15 @@ services:
     image: redis:latest
     ports:
       - "6380:6379"
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.1
+    container_name: elasticsearch
+    environment:
+      - discovery.type=single-node
+      - http.host=0.0.0.0
+      - transport.host=127.0.0.1
+      - xpack.security.enabled=false
+    ports:
+      - "9200:9200"
+      - "9300:9300"

--- a/tests/integrations/docker-compose.postgres11.yml
+++ b/tests/integrations/docker-compose.postgres11.yml
@@ -14,3 +14,15 @@ services:
     image: redis:latest
     ports:
       - "6380:6379"
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.1
+    container_name: elasticsearch
+    environment:
+      - discovery.type=single-node
+      - http.host=0.0.0.0
+      - transport.host=127.0.0.1
+      - xpack.security.enabled=false
+    ports:
+      - "9200:9200"
+      - "9300:9300"

--- a/tests/integrations/docker-compose.postgres12.yml
+++ b/tests/integrations/docker-compose.postgres12.yml
@@ -14,3 +14,15 @@ services:
     image: redis:latest
     ports:
       - "6380:6379"
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.1
+    container_name: elasticsearch
+    environment:
+      - discovery.type=single-node
+      - http.host=0.0.0.0
+      - transport.host=127.0.0.1
+      - xpack.security.enabled=false
+    ports:
+      - "9200:9200"
+      - "9300:9300"

--- a/tests/integrations/docker-compose.postgres13.yml
+++ b/tests/integrations/docker-compose.postgres13.yml
@@ -14,3 +14,15 @@ services:
     image: redis:latest
     ports:
       - "6380:6379"
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.1
+    container_name: elasticsearch
+    environment:
+      - discovery.type=single-node
+      - http.host=0.0.0.0
+      - transport.host=127.0.0.1
+      - xpack.security.enabled=false
+    ports:
+      - "9200:9200"
+      - "9300:9300"

--- a/tests/integrations/docker-compose.postgres14.yml
+++ b/tests/integrations/docker-compose.postgres14.yml
@@ -14,3 +14,15 @@ services:
     image: redis:latest
     ports:
       - "6380:6379"
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.1
+    container_name: elasticsearch
+    environment:
+      - discovery.type=single-node
+      - http.host=0.0.0.0
+      - transport.host=127.0.0.1
+      - xpack.security.enabled=false
+    ports:
+      - "9200:9200"
+      - "9300:9300"

--- a/tests/integrations/docker-compose.postgres15.yml
+++ b/tests/integrations/docker-compose.postgres15.yml
@@ -14,3 +14,15 @@ services:
     image: redis:latest
     ports:
       - "6380:6379"
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.1
+    container_name: elasticsearch
+    environment:
+      - discovery.type=single-node
+      - http.host=0.0.0.0
+      - transport.host=127.0.0.1
+      - xpack.security.enabled=false
+    ports:
+      - "9200:9200"
+      - "9300:9300"

--- a/tests/integrations/docker-compose.sqlite.yml
+++ b/tests/integrations/docker-compose.sqlite.yml
@@ -5,3 +5,15 @@ services:
     image: redis:latest
     ports:
       - "6380:6379"
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.1
+    container_name: elasticsearch
+    environment:
+      - discovery.type=single-node
+      - http.host=0.0.0.0
+      - transport.host=127.0.0.1
+      - xpack.security.enabled=false
+    ports:
+      - "9200:9200"
+      - "9300:9300"

--- a/tests/integrations/package-lock.json
+++ b/tests/integrations/package-lock.json
@@ -42,7 +42,7 @@
       }
     },
     "../..": {
-      "version": "1.0.0-rc29",
+      "version": "1.0.0-rc30",
       "integrity": "sha512-0COSAR9NskY45YKad12CIwF/uJ+HOcWbJ9lSgfhr8jIgOo4x620//HdmqHydl5Ezypc6laZERnRZ4h2Rw8Xtkg==",
       "license": "MIT",
       "dependencies": {
@@ -64,6 +64,7 @@
         "@babel/core": "^7.22.11",
         "@babel/preset-env": "^7.22.14",
         "@babel/preset-typescript": "^7.22.11",
+        "@elastic/elasticsearch": "^8.10.0",
         "@types/accept-language-parser": "^1.5.3",
         "@types/aws-lambda": "^8.10.119",
         "@types/cors": "^2.8.13",

--- a/tests/integrations/scenarios/app/config.ts
+++ b/tests/integrations/scenarios/app/config.ts
@@ -41,6 +41,12 @@ const config: IApplicationConfig = {
   cache: {
     enable: false,
   },
+  elasticSearch: {
+    node: "http://127.0.0.1:9200",
+  },
+  search: {
+    indexPrefix: "axe",
+  },
 };
 
 export default config;

--- a/tests/integrations/scenarios/app/v1/Models/Category.ts
+++ b/tests/integrations/scenarios/app/v1/Models/Category.ts
@@ -6,7 +6,11 @@ class Category extends Model {
   }
 
   get handlers() {
-    return [...DEFAULT_HANDLERS, HandlerTypes.ALL];
+    return [...DEFAULT_HANDLERS, HandlerTypes.ALL, HandlerTypes.SEARCH];
+  }
+
+  get search() {
+    return ["title"];
   }
 
   categories() {

--- a/tests/integrations/scenarios/tests/09-full-text-search.spec.js
+++ b/tests/integrations/scenarios/tests/09-full-text-search.spec.js
@@ -1,0 +1,36 @@
+/* eslint-disable no-undef */
+import axios from "axios";
+import dotenv from "dotenv";
+import { truncate } from "./helper.js";
+
+axios.defaults.baseURL = "http://localhost:3000/api";
+axios.defaults.headers.post["Content-Type"] = "application/json";
+axios.defaults.headers.get["Content-Type"] = "application/json";
+
+describe("Axe API Full-text search", () => {
+  beforeAll(async () => {
+    dotenv.config();
+    return await truncate("categories");
+  });
+
+  afterAll(async () => {
+    return await truncate("categories");
+  });
+
+  test("should search via Elasticsearch", async () => {
+    const { data: result1 } = await axios.post("/v1/categories", {
+      title: "Testable category title",
+    });
+
+    expect(result1.title).toBe("Testable category title");
+
+    // wait a second for index completed.
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    const { data: result2 } = await axios.get(
+      "/v1/categories/search?text=category",
+    );
+    expect(result2.data.length).toBe(1);
+    expect(result2.data[0].title).toBe("Testable category title");
+  });
+});


### PR DESCRIPTION
## Description

Axe API supports the LIKE queries but they are not performant. Because of that, Axe API should support a simple full-text search feature via [Elasticsearch](https://www.elastic.co/).

It should be activated quickly, and be simple. However, it should allow developers to create their custom search queries.

All the time developers are able to add their custom ES logic to their APIs by using [Hooks and Events](https://axe-api.com/learn/hooks-and-events.html). That's why Axe API shouldn't support advanced ES features.

- https://github.com/axe-api/axe-api/issues/276

## Types of changes

- [x] New feature

## Checklist:

- [x] The changes have been documented (https://github.com/axe-api/docs/pull/68)
- [x] I added integration tests properly.
