### PR TITLE
#557 - autoRouting doesn't work when the model file has a relation to two different submodels

### DIFF
--- a/src/Builders/RouterBuilder.ts
+++ b/src/Builders/RouterBuilder.ts
@@ -150,7 +150,8 @@ class RouterBuilder {
 
     // We should different parameter name for child routes
     const subRelations = model.relations.filter(
-      (item) => item.type === Relationships.HAS_MANY,
+      (item) =>
+        item.type === Relationships.HAS_MANY && item.options.autoRouting,
     );
     for (const relation of subRelations) {
       const child = model.children.find((item) => item.name === relation.model);

--- a/tests/integrations/package-lock.json
+++ b/tests/integrations/package-lock.json
@@ -44,7 +44,7 @@
       }
     },
     "../..": {
-      "version": "1.4.4",
+      "version": "1.4.5",
       "integrity": "sha512-0COSAR9NskY45YKad12CIwF/uJ+HOcWbJ9lSgfhr8jIgOo4x620//HdmqHydl5Ezypc6laZERnRZ4h2Rw8Xtkg==",
       "license": "MIT",
       "dependencies": {
@@ -90,7 +90,7 @@
         "eslint-plugin-import": "^2.30.0",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^6.6.0",
-        "eslint-plugin-unicorn": "^55.0.0",
+        "eslint-plugin-unicorn": "^56.0.0",
         "eslint-watch": "^8.0.0",
         "glob": "^11.0.0",
         "husky": "^9.1.6",
@@ -103,7 +103,7 @@
         "pg": "^8.13.0",
         "prettier": "^3.3.3",
         "redis": "^4.7.0",
-        "robust-validator": "^1.1.1",
+        "robust-validator": "^2.0.1",
         "serve-static": "^1.16.2",
         "set-value": ">=4.1.0",
         "sqlite3": "^5.1.7",

--- a/tests/integrations/scenarios/app/v1/Models/Feed.ts
+++ b/tests/integrations/scenarios/app/v1/Models/Feed.ts
@@ -12,6 +12,10 @@ class Feed extends Model {
   views() {
     return this.hasMany("FeedView", "id", "feed_id");
   }
+
+  another() {
+    return this.hasMany("FeedView", "id", "feed_id", { autoRouting: false });
+  }
 }
 
 export default Feed;

--- a/tests/integrations/scenarios/tests/05-models.spec.js
+++ b/tests/integrations/scenarios/tests/05-models.spec.js
@@ -129,4 +129,9 @@ describe("Axe API Models", () => {
     const { data } = await axios.get("/../routes");
     expect(data.includes("POST /api/v1/feeds/:feedId/views")).toBe(true);
   });
+
+  test("should not be able see the route when the auto-routing feauture is disabled", async () => {
+    const { data } = await axios.get("/../routes");
+    expect(data.includes("POST /api/v1/feeds/:feedId/another")).toBe(false);
+  });
 });

--- a/tests/unit/Builders/RouteBuilder.spec.ts
+++ b/tests/unit/Builders/RouteBuilder.spec.ts
@@ -25,6 +25,7 @@ postService.relations = [
     model: "PostLike",
     primaryKey: "id",
     foreignKey: "post_id",
+    options: { autoRouting: true },
   } as IRelation,
 ];
 const commentService = new ModelService("Comment", new Comment());


### PR DESCRIPTION
https://github.com/axe-api/axe-api/issues/557